### PR TITLE
ci: do not renovate dagger module go.mod

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,8 +7,12 @@
     ":labels(automated,no-issue)",
     "customManagers:githubActionsVersions",
     ":automergeMinor",
-    ":automergeDigest",
+    ":automergeDigest"
   ],
+  "gomod": {
+    // Do not manage the dagger go.mod file
+    "ignorePaths": ["dagger/gotest/go.mod"],
+  },
   "postUpdateOptions": [
     "gomodTidy"
   ],
@@ -42,7 +46,7 @@
         "patch",
         "digest"
       ],
-      "groupName": "all non-major go dependencies",
+      "groupName": "all non-major go dependencies"
     },
     {
       "matchDatasources": [
@@ -54,14 +58,14 @@
       "matchUpdateTypes": [
         "digest"
       ],
-      "groupName": "all cloudnative-pg daggerverse dependencies",
+      "groupName": "all cloudnative-pg daggerverse dependencies"
     },
     {
       "matchUpdateTypes": [
         "minor",
         "patch"
       ],
-      "matchCurrentVersion": "!/^0/",
+      "matchCurrentVersion": "!/^0/"
     }
   ]
 }


### PR DESCRIPTION
The file is set up by dagger itself, and managed with "dagger develop". We exclude it from the automatic maintenance.