### PR TITLE
feat: nanosecond-precision logging

### DIFF
--- a/pkg/log/flags.go
+++ b/pkg/log/flags.go
@@ -84,6 +84,10 @@ func GetFieldsRemapFlags() (res []string) {
 // passed from the user
 // This is executed after args were already parsed.
 func (l *Flags) ConfigureLogging() {
+	if l.zapOptions.TimeEncoder == nil {
+		l.zapOptions.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}
+
 	logger := zap.New(zap.UseFlagOptions(&l.zapOptions), customLevel, customDestination, remapKeys)
 	switch logLevel {
 	case ErrorLevelString,

--- a/pkg/log/flags.go
+++ b/pkg/log/flags.go
@@ -85,7 +85,7 @@ func GetFieldsRemapFlags() (res []string) {
 // This is executed after args were already parsed.
 func (l *Flags) ConfigureLogging() {
 	if l.zapOptions.TimeEncoder == nil {
-		l.zapOptions.TimeEncoder = zapcore.ISO8601TimeEncoder
+		l.zapOptions.TimeEncoder = zapcore.RFC3339NanoTimeEncoder
 	}
 
 	logger := zap.New(zap.UseFlagOptions(&l.zapOptions), customLevel, customDestination, remapKeys)


### PR DESCRIPTION
Unless otherwise set, the logging module default to having nanosecond precision with `RFC3339NanoTimeEncoder`.

Relates: https://github.com/cloudnative-pg/cloudnative-pg/issues/5782