### PR TITLE
fix: archive WAL file once, not twice

### DIFF
--- a/pkg/fileutils/wals/wals.go
+++ b/pkg/fileutils/wals/wals.go
@@ -85,7 +85,8 @@ func (c GatherReadyWALFilesConfig) getPgDataPath() string {
 
 func (c GatherReadyWALFilesConfig) shouldSkipWAL(walPath string) bool {
 	for _, walToSkip := range c.SkipWALs {
-		if strings.HasSuffix(walPath, walToSkip) {
+		walNameToSkip := path.Base(walToSkip) + ".ready"
+		if strings.HasSuffix(walPath, walNameToSkip) {
 			return true
 		}
 	}

--- a/pkg/fileutils/wals/wals_test.go
+++ b/pkg/fileutils/wals/wals_test.go
@@ -74,7 +74,7 @@ var _ = Describe("WALList functions", func() {
 		Expect(result.HasMoreResults).To(BeFalse())
 	})
 
-	It("gathers ready WAL files with skip one", func() {
+	It("gathers ready WAL files with one skipped", func() {
 		result := GatherReadyWALFiles(ctx, GatherReadyWALFilesConfig{
 			MaxResults: 10, PgDataPath: tmpDir, SkipWALs: []string{"pg_wal/000000010000000000000001"},
 		})

--- a/pkg/fileutils/wals/wals_test.go
+++ b/pkg/fileutils/wals/wals_test.go
@@ -74,6 +74,19 @@ var _ = Describe("WALList functions", func() {
 		Expect(result.HasMoreResults).To(BeFalse())
 	})
 
+	It("gathers ready WAL files with skip one", func() {
+		result := GatherReadyWALFiles(ctx, GatherReadyWALFilesConfig{
+			MaxResults: 10, PgDataPath: tmpDir, SkipWALs: []string{"pg_wal/000000010000000000000001"},
+		})
+		Expect(result.Ready).ToNot(
+			ContainElement(
+				path.Join(tmpDir, "pg_wal/000000010000000000000001")))
+		Expect(
+			result.Ready).To(
+			ContainElement(path.Join(tmpDir, "pg_wal/000000010000000000000002")))
+		Expect(result.HasMoreResults).To(BeFalse())
+	})
+
 	It("handles no more WAL files needed", func() {
 		result := GatherReadyWALFiles(ctx, GatherReadyWALFilesConfig{MaxResults: 1, PgDataPath: tmpDir})
 		Expect(result.Ready).To(HaveLen(1))


### PR DESCRIPTION
This commit fixes an issue in the `shouldSkipWal` method of the `GatherReadyWALFilesConfig` struct, where the current WAL file to upload is not skipped from the gathered "ready" WAL list.

We noticed the issue because the WAL archive GCP service account doesn't have permission to delete objects in our object storage.

You can see in the logs that the WAL archive attempts to upload the same WAL file twice, but with different paths:

```
{"level":"info","ts":"2025-02-13T20:40:32.321415133Z","logger":"wal-archive","msg":"Executing barman-cloud-wal-archive","logging_pod":"backup-test-1","walName":"/var/lib/postgresql/data/pgdata/pg_wal/00000001000000040000001D","options":["--snappy","--cloud-provider","google-cloud-storage","gs://my-backup-storage","backup-test","/var/lib/postgresql/data/pgdata/pg_wal/00000001000000040000001D"]}
{"level":"info","ts":"2025-02-13T20:40:32.321448373Z","logger":"wal-archive","msg":"Executing barman-cloud-wal-archive","logging_pod":"backup-test-1","walName":"pg_wal/00000001000000040000001D","options":["--snappy","--cloud-provider","google-cloud-storage","gs://my-backup-storage","backup-test","pg_wal/00000001000000040000001D"]}
{"level":"info","ts":"2025-02-13T20:40:33.046761842Z","logger":"wal-archive","msg":"Archived WAL file","logging_pod":"backup-test-1","walName":"pg_wal/00000001000000040000001D","startTime":"2025-02-13T20:40:32.321422342Z","endTime":"2025-02-13T20:40:33.046732582Z","elapsedWalTime":0.725310229}
{"level":"error","ts":"2025-02-13T20:40:33.052585332Z","logger":"wal-archive","msg":"Error invoking barman-cloud-wal-archive","logging_pod":"backup-test-1","walName":"/var/lib/postgresql/data/pgdata/pg_wal/00000001000000040000001D","options":["--snappy","--cloud-provider","google-cloud-storage","gs://my-backup-storage","backup-test","/var/lib/postgresql/data/pgdata/pg_wal/00000001000000040000001D"],"exitCode":-1,"error":"exit status 4","stacktrace":"github.com/cloudnative-pg/machinery/pkg/log.(*logger).Error\n\tpkg/mod/github.com/cloudnative-pg/machinery@v0.0.0-20241219102532-2807bc88310d/pkg/log/log.go:125\ngithub.com/cloudnative-pg/barman-cloud/pkg/walarchive.(*BarmanArchiver).Archive\n\tpkg/mod/github.com/cloudnative-pg/barman-cloud@v0.0.0-20241218093921-134c7de4954a/pkg/walarchive/cmd.go:83\ngithub.com/cloudnative-pg/barman-cloud/pkg/walarchive.(*BarmanArchiver).ArchiveList.func1\n\tpkg/mod/github.com/cloudnative-pg/barman-cloud@v0.0.0-20241218093921-134c7de4954a/pkg/walarchive/cmd.go:115"}
{"level":"info","ts":"2025-02-13T20:40:33.052700252Z","logger":"wal-archive","msg":"Failed archiving WAL: PostgreSQL will retry","logging_pod":"backup-test-1","walName":"/var/lib/postgresql/data/pgdata/pg_wal/00000001000000040000001D","startTime":"2025-02-13T20:40:32.321394422Z","endTime":"2025-02-13T20:40:33.052693952Z","elapsedWalTime":0.7312995,"error":"unexpected failure invoking barman-cloud-wal-archive: exit status 4"}
{"level":"info","ts":"2025-02-13T20:40:33.052745862Z","logger":"wal-archive","msg":"Completed archive command (parallel)","logging_pod":"backup-test-1","walsCount":2,"startTime":"2025-02-13T20:40:32.230839745Z","uploadStartTime":"2025-02-13T20:40:32.321364142Z","uploadTotalTime":0.73136885,"totalTime":0.821893557}
```

Feel free to update the code if you think the ".ready" concatenation should be placed elsewhere.